### PR TITLE
fix(week display): display both months when needed

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -3,7 +3,7 @@ function Calendar(calendarContainerId, userProvidedConfigs) {
   this.calendarConfigs = userProvidedConfigs;
   this.uniqueCalendarId = calendarContainerId;
 
-  this.monthNumber = 0;
+  this.nthMonthFromCurrentMonth = 0;
   this.nthWeekFromCurrentWeek = 0;
 
   this.render = render.bind(this);

--- a/modules/month.js
+++ b/modules/month.js
@@ -51,14 +51,14 @@ function initMonthNavButtons() {
   document
     .getElementById(`nextMonth_${this.uniqueCalendarId}`)
     .addEventListener("click", () => {
-      this.monthNumber++;
+      this.nthMonthFromCurrentMonth++;
       this.renderMonthView();
     });
 
   document
     .getElementById(`previousMonth_${this.uniqueCalendarId}`)
     .addEventListener("click", () => {
-      this.monthNumber--;
+      this.nthMonthFromCurrentMonth--;
       this.renderMonthView();
     });
 }
@@ -66,8 +66,8 @@ function initMonthNavButtons() {
 function renderMonthView() {
   const currentDate = new Date();
 
-  if (this.monthNumber !== 0) {
-    currentDate.setMonth(new Date().getMonth() + this.monthNumber);
+  if (this.nthMonthFromCurrentMonth !== 0) {
+    currentDate.setMonth(new Date().getMonth() + this.nthMonthFromCurrentMonth);
   }
 
   const month = currentDate.getMonth();

--- a/modules/week.js
+++ b/modules/week.js
@@ -77,12 +77,16 @@ function renderWeekView() {
 
   const year = currentDate.getFullYear();
   const weekStartDate = weekDates[0].getDate();
-  const monthString = weekDates[0].toString().split(" ")[1];
+  const weekStartMonth = weekDates[0].toString().split(" ")[1];
+  const weekEndMonth = weekDates[6].toString().split(" ")[1];
   const weekEndDate = weekDates[6].getDate();
   const weekDisplay = document.getElementById(
     `weekDisplay_${this.uniqueCalendarId}`
   );
-  weekDisplay.innerText = `${monthString} ${weekStartDate}-${weekEndDate}, ${year}`;
+  weekDisplay.innerText =
+    weekStartMonth === weekEndMonth
+      ? `${weekStartMonth} ${weekStartDate}-${weekEndDate}, ${year}`
+      : `${weekStartMonth} ${weekStartDate} - ${weekEndMonth} ${weekEndDate}, ${year}`;
 
   weekDatesRow.innerHTML = "<th></th>"; //Empty cell before the Week dates
 


### PR DESCRIPTION
Closes Issue #4 
## Bug
- The display of week view should show both months if the week spans across 2 months, but it's only showing the starting month.
## Fix
- Compared the month of the first day of week with that of the last day and displayed correct heading accordingly.
## Refactor
- Changed variable name of `monthNumber` to `nthMonthFromCurrentMonth`