### PR TITLE
Added Day view

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,9 @@
 
   <script src="./modules/utils.js"></script>
   <script src="./modules/constants.js"></script>
-  <script src="modules/week.js"></script>
+  <script src="./modules/week.js"></script>
   <script src="./modules/month.js"></script>
+  <script src="./modules/day.js"></script>
   <script src="./modules/index.js"></script>
   <script>
     const newCalendar = new Calendar("calendar");

--- a/modules/day.js
+++ b/modules/day.js
@@ -1,0 +1,15 @@
+function renderHourRowsOfADay(dateToDisplay) {
+  const dayTableBody = document.getElementById(
+    `dayTableBody_${this.uniqueCalendarId}`
+  );
+  let allRows = ''
+  HOURS_IN_A_DAY.forEach((hour) => {
+    let singleRow = `<tr class='hourRow'>`;
+    singleRow += `<td class="hourCell">${hour}</td>`;
+    singleRow += `<td style="flex:4" data-hour=${hour} data-date=${getDateString(
+      dateToDisplay
+    )} class="hourCell"></td>`;
+    allRows += singleRow;
+  });
+  dayTableBody.innerHTML = allRows;
+}

--- a/modules/day.js
+++ b/modules/day.js
@@ -13,3 +13,41 @@ function renderHourRowsOfADay(dateToDisplay) {
   });
   dayTableBody.innerHTML = allRows;
 }
+
+function initDayNavButtons() {
+  document
+    .getElementById(`nextDay_${this.uniqueCalendarId}`)
+    .addEventListener("click", () => {
+      this.nthDateFromCurrentDate++;
+      this.renderDayView();
+    });
+
+  document
+    .getElementById(`previousDay_${this.uniqueCalendarId}`)
+    .addEventListener("click", () => {
+      this.nthDateFromCurrentDate--;
+      this.renderDayView();
+    });
+}
+
+function renderDayView() {
+  const dayDisplay = document.getElementById(
+    `dayDisplay_${this.uniqueCalendarId}`
+  );
+  const dayHeading = document.getElementById(`dayHeading_${this.uniqueCalendarId}`);
+  const dateToDisplay = new Date();
+
+  if (this.nthDayFromCurrentDay !== 0) {
+    dateToDisplay.setDate(dateToDisplay.getDate() + this.nthDateFromCurrentDate);
+  }
+  const dateComponents = dateToDisplay.toString().split(" ");
+  const yearToDisplay = dateToDisplay.getFullYear();
+  const monthStringToDisplay = dateComponents[1];
+  let weekDayOfDateToDisplay = dateComponents[0];
+  weekDayOfDateToDisplay = WEEK_DAYS.find((day)=>day.short === weekDayOfDateToDisplay)
+
+  dayDisplay.innerText = `${monthStringToDisplay} ${dateToDisplay.getDate()}, ${yearToDisplay}`;
+  dayHeading.innerHTML = `<th></th><th>${weekDayOfDateToDisplay.long}</th>`; //Empty cell before the Week dates
+
+  renderHourRowsOfADay.call(this, dateToDisplay);
+}

--- a/modules/index.js
+++ b/modules/index.js
@@ -5,14 +5,17 @@ function Calendar(calendarContainerId, userProvidedConfigs) {
 
   this.nthMonthFromCurrentMonth = 0;
   this.nthWeekFromCurrentWeek = 0;
+  this.nthDateFromCurrentDate = 0;
 
   this.render = render.bind(this);
   this.renderMonthView = renderMonthView.bind(this);
   this.renderWeekView = renderWeekView.bind(this);
+  this.renderDayView = renderDayView.bind(this);
 
   this.viewInitialisers = {
     [`monthView_${calendarContainerId}`]: this.renderMonthView,
     [`weekView_${calendarContainerId}`]: this.renderWeekView,
+    [`dayView_${calendarContainerId}`]: this.renderDayView,
   };
 
   function render() {
@@ -81,6 +84,26 @@ function Calendar(calendarContainerId, userProvidedConfigs) {
           </table>
     
         </div>
+        <div id="dayView_${uniqueCalendarId}" class="view">
+          <div class="calendarHeader">
+            <div id="dayDisplay_${uniqueCalendarId}"> </div>
+            <div class="navButtonsContainer">
+              <button id="previousDay_${uniqueCalendarId}" class="cal-button navButton">Back</button>
+              <button id="nextDay_${uniqueCalendarId}" class="cal-button navButton">Next</button>
+            </div>
+          </div>
+          <table class="viewTable">
+            <thead>
+              <tr class="tableHeadings">
+                <th id="dayHeading_${uniqueCalendarId}"></th>
+              </tr>
+            </thead>
+            <tbody id="dayTableBody_${uniqueCalendarId}" class="dayTableBody">
+              
+            </tbody>
+          </table>
+    
+        </div>
       </div>
       `;
 
@@ -93,6 +116,7 @@ function Calendar(calendarContainerId, userProvidedConfigs) {
     this.renderMonthView();
     initMonthNavButtons.call(this);
     initWeekNavButtons.call(this);
+    initDayNavButtons.call(this);
   }
 
   function toggleView(e) {

--- a/modules/week.js
+++ b/modules/week.js
@@ -27,7 +27,7 @@ function getWeekDates(anyDateOfTheWeek) {
   return weekDates;
 }
 
-function renderHourRows(weekStartDate) {
+function renderHourRowsOfAWeek(weekStartDate) {
   const weekTableBody = document.getElementById(
     `weekTableBody_${this.uniqueCalendarId}`
   );
@@ -97,5 +97,5 @@ function renderWeekView() {
     dateCell.innerText = dateString;
     weekDatesRow.appendChild(dateCell);
   });
-  renderHourRows.call(this, weekDates[0]);
+  renderHourRowsOfAWeek.call(this, weekDates[0]);
 }


### PR DESCRIPTION
## Overview
- Users can toggle the view mode to `day`
- Created function `renderDayView` to render the day view in calendar, it has 2 helper functions:
   1. `renderHourRowsOfTheDay`:
       - Creates hour rows for the day & inserts them into the dayTable body
   3. `initDayNavButtons`:
       - Adds click eventHandlers to nav buttons to navigate between days.
## Preview
- Demo: https://calendar-plugin-git-day-view-kjais1720.vercel.app/
- Snapshot:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/66024105/187269207-1493b006-4bd4-4624-a05a-f52a9b731753.png">
