### PR TITLE
fix: change method to calculate the display month from currentDate

### DIFF
--- a/modules/month.js
+++ b/modules/month.js
@@ -64,19 +64,22 @@ function initMonthNavButtons() {
 }
 
 function renderMonthView() {
-  const currentDate = new Date();
-  const monthToDisplay = currentDate.getMonth() + this.nthMonthFromCurrentMonth;
-  const yearToDisplay = currentDate.getFullYear();
+  const firstDateOfDisplayMonth = new Date();
+  firstDateOfDisplayMonth.setDate(1); //To avoid the edge case at 31st of a month
+  if (this.nthMonthFromCurrentMonth !== 0) {
+    firstDateOfDisplayMonth.setMonth(firstDateOfDisplayMonth.getMonth() + this.nthMonthFromCurrentMonth);
+  }
+  const month = firstDateOfDisplayMonth.getMonth()
+  const year = firstDateOfDisplayMonth.getFullYear();
 
-  const firstDateOfMonth = new Date(yearToDisplay, monthToDisplay, 1);
-  const lastdateOfMonth = new Date(yearToDisplay, monthToDisplay + 1, 0);
+  const lastDateOfDisplayMonth = new Date(year, month + 1, 0);
 
   const monthDisplay = document.getElementById(
     `monthDisplay_${this.uniqueCalendarId}`
   );
-  monthDisplay.innerText = `${firstDateOfMonth.toLocaleDateString("en-us", {
+  monthDisplay.innerText = `${firstDateOfDisplayMonth.toLocaleDateString("en-us", {
     month: "long",
-  })} ${yearToDisplay}`;
+  })} ${year}`;
 
-  renderDateRows.call(this, firstDateOfMonth, lastdateOfMonth);
+  renderDateRows.call(this, firstDateOfDisplayMonth, lastDateOfDisplayMonth);
 }

--- a/modules/month.js
+++ b/modules/month.js
@@ -65,23 +65,18 @@ function initMonthNavButtons() {
 
 function renderMonthView() {
   const currentDate = new Date();
+  const monthToDisplay = currentDate.getMonth() + this.nthMonthFromCurrentMonth;
+  const yearToDisplay = currentDate.getFullYear();
 
-  if (this.nthMonthFromCurrentMonth !== 0) {
-    currentDate.setMonth(new Date().getMonth() + this.nthMonthFromCurrentMonth);
-  }
-
-  const month = currentDate.getMonth();
-  const year = currentDate.getFullYear();
-
-  const firstDateOfMonth = new Date(year, month, 1);
-  const lastdateOfMonth = new Date(year, month + 1, 0);
+  const firstDateOfMonth = new Date(yearToDisplay, monthToDisplay, 1);
+  const lastdateOfMonth = new Date(yearToDisplay, monthToDisplay + 1, 0);
 
   const monthDisplay = document.getElementById(
     `monthDisplay_${this.uniqueCalendarId}`
   );
-  monthDisplay.innerText = `${currentDate.toLocaleDateString("en-us", {
+  monthDisplay.innerText = `${firstDateOfMonth.toLocaleDateString("en-us", {
     month: "long",
-  })} ${year}`;
+  })} ${yearToDisplay}`;
 
   renderDateRows.call(this, firstDateOfMonth, lastdateOfMonth);
 }


### PR DESCRIPTION
PR for Issue #7 ( closes #7 )
## Issue
- If the current date is 31st of any month (other than July), then clicking the next ( or previous ) month button will skip the  next month and display the month after the next month.
## Cause
- Earlier, the next month was being calculated by incrementing the month of the currentDate using the method `setMonth()` like `currentDate.setMonth(currrentDate.getMonth() + incrementMonthBy)`, so if the current date was 31st then it would add 1 month the date, but since the next month doesn't have 31st date so it was skipped.
## Resolution
- First set the current date to the first date of month then increment the month.