### PR TITLE
Fixed extra rows bug in week table

### DIFF
--- a/modules/day.js
+++ b/modules/day.js
@@ -9,6 +9,7 @@ function renderHourRowsOfADay(dateToDisplay) {
     singleRow += `<td style="flex:4" data-hour=${hour} data-date=${getDateString(
       dateToDisplay
     )} class="hourCell"></td>`;
+    singleRow += "</tr>"
     allRows += singleRow;
   });
   dayTableBody.innerHTML = allRows;

--- a/modules/week.js
+++ b/modules/week.js
@@ -31,20 +31,21 @@ function renderHourRowsOfAWeek(weekStartDate) {
   const weekTableBody = document.getElementById(
     `weekTableBody_${this.uniqueCalendarId}`
   );
+  let allRows = '';
   HOURS_IN_A_DAY.forEach((hour) => {
-    const row = document.createElement("tr");
-    row.className = "hourRow";
-    let rowHTML = `<td class="hourCell">${hour}</td>`;
+    let singleRow = `<tr class='hourRow'>`;
+    singleRow += `<td class="hourCell">${hour}</td>`;
     for (let i = 0; i < 7; i++) {
       const dateOfCurrentCell = new Date(weekStartDate);
       dateOfCurrentCell.setDate(dateOfCurrentCell.getDate() + i);
-      rowHTML += `<td data-hour=${hour} data-date=${getDateString(
+      singleRow += `<td data-hour=${hour} data-date=${getDateString(
         dateOfCurrentCell
       )} class="hourCell"></td>`;
     }
-    row.innerHTML = rowHTML;
-    weekTableBody.appendChild(row);
+    singleRow += "</tr>"
+    allRows += singleRow;
   });
+  weekTableBody.innerHTML = allRows
 }
 
 function initWeekNavButtons() {


### PR DESCRIPTION
PR for Issue #9 ( closes #9 )
## Issue:
- When navigating between different weeks, new rows were being appended to the table instead of replacing the old ones.
## Solution:
- In the function `renderHourRowsOfWeek`, instead of appending each row to the table body, set the innerHTML with the rows.